### PR TITLE
fix(package): based on a babel bug, no src directory is created

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   ],
   "packageManager": "yarn@3.1.1",
   "sideEffects": false,
-  "main": "dist/src/index.js",
-  "module": "dist/src/index.js",
-  "jsnext:main": "dist/src/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "jsnext:main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
## Summary

## Type

- Bug

When we build our package, there is no src directory.

https://github.com/rollup/rollup/issues/3684

