### PR TITLE
feat: handle when multiple errors, get first valid string

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@emotion/styled": "11.6.0",
     "@scaleway/ui": "0.123.0",
     "final-form": "4.20.6",
+    "final-form-arrays": "^3.0.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-final-form": "6.5.7"
@@ -171,6 +172,7 @@
     "@babel/runtime": "7.16.7",
     "@scaleway/ui": "0.123.0",
     "final-form": "4.20.6",
+    "final-form-arrays": "^3.0.2",
     "react-final-form": "6.5.7"
   },
   "dependenciesMeta": {

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -1,4 +1,5 @@
 import { Config } from 'final-form'
+import arrayMutators from 'final-form-arrays'
 import React, { ReactNode } from 'react'
 import {
   FormRenderProps,
@@ -26,6 +27,8 @@ export type FormProps<FormValues = unknown> = {
   render?: RenderableProps<
     FormRenderProps<FormValues, Partial<FormValues>>
   >['render']
+  mutators?: Config<FormValues, Partial<FormValues>>['mutators']
+  keepDirtyOnReinitialize?: boolean
 }
 const Form = <T,>({
   children,
@@ -38,12 +41,18 @@ const Form = <T,>({
   validate,
   name,
   render,
+  mutators,
+  keepDirtyOnReinitialize,
 }: FormProps<T>): JSX.Element => (
   <ErrorProvider errors={errors}>
     <ReactFinalForm
       initialValues={initialValues}
       validateOnBlur={validateOnBlur}
       validate={validate}
+      mutators={{
+        ...arrayMutators,
+        ...mutators,
+      }}
       onSubmit={async (values, form, callback) => {
         try {
           const res = await onSubmit?.(values, form, callback)
@@ -64,6 +73,7 @@ const Form = <T,>({
           </form>
         ))
       }
+      keepDirtyOnReinitialize={keepDirtyOnReinitialize}
     />
   </ErrorProvider>
 )

--- a/src/hooks/__tests__/useValidation.spec.ts
+++ b/src/hooks/__tests__/useValidation.spec.ts
@@ -45,6 +45,6 @@ describe('useValidation', () => {
     const { result } = renderHook(() =>
       useValidation({ validate: () => false, validators: [] }),
     )
-    expect(result.current(false, {})).toStrictEqual([false])
+    expect(result.current(false, {})).toStrictEqual(false)
   })
 })

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -22,18 +22,18 @@ const useValidation = <T = unknown>({
       value: T,
       allValues: AnyObject,
       meta?: FieldState<T>,
-    ): Array<string | unknown> | undefined => {
-      const errors = validators
-        .filter(validator => !validator.validate(value, allValues, meta))
-        .map(({ error }) => error) as Array<string | unknown>
-
+    ): Array<string | unknown> | unknown | undefined => {
       if (validate) {
         const validateErr = validate(value, allValues, meta) as
           | unknown
           | undefined
         if (validateErr !== undefined && validateErr !== true)
-          errors.push(validateErr)
+          return validateErr
       }
+
+      const errors = validators
+        .filter(validator => !validator.validate(value, allValues, meta))
+        .map(({ error }) => error) as Array<string | unknown>
 
       return errors.length > 0 ? errors : undefined
     },

--- a/src/providers/ErrorContext/__tests__/index.spec.tsx
+++ b/src/providers/ErrorContext/__tests__/index.spec.tsx
@@ -33,7 +33,7 @@ describe('ErrorProvider', () => {
         meta: {
           blur: () => {},
           change: () => {},
-          error: 'REQUIRED',
+          error: ['REQUIRED'],
           focus: () => {},
           name: 'test',
         },
@@ -49,7 +49,7 @@ describe('ErrorProvider', () => {
         meta: {
           blur: () => {},
           change: () => {},
-          error: 'MIN_LENGTH',
+          error: ['MIN_LENGTH'],
           focus: () => {},
           name: 'test',
         },

--- a/src/providers/ErrorContext/index.tsx
+++ b/src/providers/ErrorContext/index.tsx
@@ -33,20 +33,26 @@ const ErrorProvider = ({
       meta,
       ...additionalParams
     }: FormErrorFunctionParams & AnyObject) => {
-      if (meta?.error && errors[meta.error as keyof typeof errors]) {
-        const key = meta.error as keyof typeof errors
-        if (typeof errors[key] === 'function') {
-          return (errors[key] as (params: AnyObject) => string)({
-            allValues,
-            label,
-            meta,
-            name,
-            value,
-            ...additionalParams,
-          })
-        }
+      if (meta?.error && Array.isArray(meta.error)) {
+        return (
+          meta.error
+            .map(untypedKey => {
+              const key = untypedKey as keyof typeof errors
+              if (typeof errors[key] === 'function') {
+                return (errors[key] as (params: AnyObject) => string)({
+                  allValues,
+                  label,
+                  meta,
+                  name,
+                  value,
+                  ...additionalParams,
+                })
+              }
 
-        return errors[key]
+              return errors[key]
+            })
+            .filter(errorString => !!errorString)[0] ?? ''
+        )
       }
       // With a custom validate function the user may return a string directly
       if (meta?.error && typeof meta?.error === 'string') return meta?.error

--- a/yarn.lock
+++ b/yarn.lock
@@ -3388,6 +3388,7 @@ __metadata:
     eslint: 8.6.0
     eslint-plugin-mdx: 1.16.0
     final-form: 4.20.6
+    final-form-arrays: ^3.0.2
     husky: 7.0.4
     jest: 27.4.7
     jest-junit: 13.0.0
@@ -3409,6 +3410,7 @@ __metadata:
     "@emotion/styled": 11.6.0
     "@scaleway/ui": 0.123.0
     final-form: 4.20.6
+    final-form-arrays: ^3.0.2
     react: 17.0.2
     react-dom: 17.0.2
     react-final-form: 6.5.7
@@ -11355,6 +11357,15 @@ __metadata:
   dependencies:
     to-regex-range: ^5.0.1
   checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
+  languageName: node
+  linkType: hard
+
+"final-form-arrays@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "final-form-arrays@npm:3.0.2"
+  peerDependencies:
+    final-form: ^4.18.2
+  checksum: bed684815967fa3e5b2cc91eb69e5d88e1048a5dbe421e2eb61b90434c634a09fec877ce52c85add8d009c20c052b6f2a884277d7ca80e9a628944a012d20205
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

When you set multiple constraint like maxLength and required. Try to find in all errors the first string not empty, default result is an empty string

#### The following changes where made:

1. Loop over meta.error and find the first string not empty

2. FYI TextBox with an empty error string result in no error style



