### PR TITLE
fix: remove custom error handling

### DIFF
--- a/src/mocks/mockErrors.ts
+++ b/src/mocks/mockErrors.ts
@@ -1,6 +1,6 @@
 import { FormErrors } from '../types'
 
-const mockErrors = {
+const mockErrors: FormErrors = {
   MAX_LENGTH: ({ maxLength }) =>
     `This field should have a length lower than ${maxLength}`,
   MIN_LENGTH: ({ minLength }) =>
@@ -12,6 +12,6 @@ const mockErrors = {
   REQUIRED: 'This field is required',
   TOO_HIGH: ({ max }) => `This field is too high (maximum is : ${max})`,
   TOO_LOW: 'This field is too low',
-} as FormErrors
+}
 
 export default mockErrors

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,13 +53,7 @@ type RequiredErrors = {
   REQUIRED: ((params: FormErrorFunctionParams) => string) | string
 }
 
-type AdditionalErrors = {
-  [x: string]:
-    | ((params: FormErrorFunctionParams & { [x: string]: unknown }) => string)
-    | string
-}
-
-export type FormErrors = RequiredErrors & AdditionalErrors
+export type FormErrors = RequiredErrors
 
 export type ValidatorProps = {
   required?: boolean


### PR DESCRIPTION
## Summary

Typescript does not support extended mapped types, the mapped type would overload the static FormError definition

## Type

- Bug


