### PR TITLE
feat: support Or regex syntax

### DIFF
--- a/src/validators/__tests__/regex.spec.ts
+++ b/src/validators/__tests__/regex.spec.ts
@@ -1,6 +1,7 @@
 import regex from '../regex'
 
 const alpha = /^[a-zA-Z]*$/
+const digits = /^[0-9]*$/
 
 describe('regex validator', () => {
   test('should not throw error', () => {
@@ -18,5 +19,11 @@ describe('regex validator', () => {
     const validator = regex([alpha])
     expect(validator.validate('a1', {})).toBe(false)
     expect(validator.validate('a+', {})).toBe(false)
+  })
+
+  test('should support or value', () => {
+    const validator = regex([[alpha, digits]])
+    expect(validator.validate('test', {})).toBe(true)
+    expect(validator.validate('1234', {})).toBe(true)
   })
 })

--- a/src/validators/regex.ts
+++ b/src/validators/regex.ts
@@ -1,8 +1,13 @@
 import { ValidatorFn } from './types'
 
-const validator: ValidatorFn<string, RegExp[]> = regexes => ({
+const validator: ValidatorFn<string, (RegExp | RegExp[])[]> = regexes => ({
   error: 'REGEX',
-  validate: value => regexes.every(regex => regex.test(value)),
+  validate: value =>
+    regexes.every(regex =>
+      Array.isArray(regex)
+        ? regex.some(regexOr => regexOr.test(value))
+        : regex.test(value),
+    ),
 })
 
 export default validator


### PR DESCRIPTION
## Summary

regex validator support a new syntax to allow either one regex to match

```ts
regex={[alpha, digits]} // This require input to match alpha AND digits
regex={[[alpha, digits]]} // This require input to match alpha OR digits
regex={[[alpha, digits], macAddress]} // This require input to match either (alpha or digits) AND macAddress
```

## Type

- Feature
