### PR TITLE
fix: checkbox needs to be touched before error message

### DIFF
--- a/src/components/CheckboxField/index.tsx
+++ b/src/components/CheckboxField/index.tsx
@@ -79,7 +79,7 @@ const CheckboxField = forwardRef(
 
     const error = useMemo(
       () =>
-        meta.error
+        meta.error && meta.touched
           ? getFirstError({
               allValues: values,
               label,


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Checkbox should not be showing error message directly

#### The following changes where made:

(Describe what you did)

1. add touched before showing error





