### PR TITLE
fix: passing more parameters to submit and textboxfield

### DIFF
--- a/src/components/Submit/index.tsx
+++ b/src/components/Submit/index.tsx
@@ -1,4 +1,4 @@
-import { Button, TextBox } from '@scaleway/ui'
+import { Button } from '@scaleway/ui'
 import React, { ComponentProps, ReactNode } from 'react'
 import { useFormState } from 'react-final-form'
 
@@ -6,7 +6,7 @@ type SubmitProps = {
   children?: ReactNode
   disabled?: boolean
   className?: string
-  size?: ComponentProps<typeof TextBox>['size']
+  size?: ComponentProps<typeof Button>['size']
   variant?: ComponentProps<typeof Button>['variant']
 }
 

--- a/src/components/Submit/index.tsx
+++ b/src/components/Submit/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@scaleway/ui'
+import { Button, TextBox } from '@scaleway/ui'
 import React, { ComponentProps, ReactNode } from 'react'
 import { useFormState } from 'react-final-form'
 
@@ -6,6 +6,7 @@ type SubmitProps = {
   children?: ReactNode
   disabled?: boolean
   className?: string
+  size?: ComponentProps<typeof TextBox>['size']
   variant?: ComponentProps<typeof Button>['variant']
 }
 
@@ -13,6 +14,7 @@ const Submit = ({
   children,
   disabled = false,
   variant = 'success',
+  size,
   className,
 }: SubmitProps): JSX.Element => {
   const { invalid, submitting, hasValidationErrors, dirtySinceLastSubmit } =
@@ -36,6 +38,7 @@ const Submit = ({
       variant={variant}
       type="submit"
       className={className}
+      size={size}
     >
       {children}
     </Button>

--- a/src/components/TextBoxField/index.tsx
+++ b/src/components/TextBoxField/index.tsx
@@ -47,6 +47,8 @@ type TextBoxFieldProps<T = TextBoxValue, K = string> = BaseFieldProps<T, K> &
   > & {
     name: string
     className?: string
+    max?: number
+    min?: number
     regex?: (RegExp | RegExp[])[]
   }
 
@@ -72,7 +74,9 @@ const TextBoxField = forwardRef(
       initialValue,
       isEqual,
       label = '',
+      max,
       maxLength,
+      min,
       minLength,
       multiline,
       multiple,
@@ -103,7 +107,9 @@ const TextBoxField = forwardRef(
     const validateFn = useValidation<TextBoxValue>({
       validate,
       validators: pickValidators({
+        max,
         maxLength,
+        min,
         minLength,
         regex,
         required,
@@ -135,8 +141,10 @@ const TextBoxField = forwardRef(
           ? getFirstError<string>({
               allValues: values,
               label,
+              max,
               maxLength,
               meta: meta as FieldState<string>,
+              min,
               minLength,
               name,
               regex,
@@ -147,8 +155,10 @@ const TextBoxField = forwardRef(
         getFirstError,
         input.value,
         label,
+        max,
         maxLength,
         meta,
+        min,
         minLength,
         name,
         regex,
@@ -175,7 +185,9 @@ const TextBoxField = forwardRef(
         multiline={multiline}
         name={input.name}
         notice={notice}
-        onBlur={(event: FocusEvent<HTMLTextAreaElement>) => {
+        max={max}
+        min={min}
+        onBlur={(event: FocusEvent<HTMLInputElement>) => {
           input.onBlur(event)
           onBlur?.(event)
         }}
@@ -183,7 +195,7 @@ const TextBoxField = forwardRef(
           input.onChange(event)
           onChange?.(event)
         }}
-        onFocus={(event: FocusEvent<HTMLTextAreaElement>) => {
+        onFocus={(event: FocusEvent<HTMLInputElement>) => {
           input.onFocus(event)
           onFocus?.(event)
         }}

--- a/src/components/TextBoxField/index.tsx
+++ b/src/components/TextBoxField/index.tsx
@@ -42,12 +42,11 @@ type TextBoxFieldProps<T = TextBoxValue, K = string> = BaseFieldProps<T, K> &
       | 'rows'
       | 'type'
       | 'value'
+      | 'size'
     >
   > & {
     name: string
     className?: string
-    max?: number
-    min?: number
     regex?: (RegExp | RegExp[])[]
   }
 
@@ -73,9 +72,7 @@ const TextBoxField = forwardRef(
       initialValue,
       isEqual,
       label = '',
-      max,
       maxLength,
-      min,
       minLength,
       multiline,
       multiple,
@@ -96,6 +93,7 @@ const TextBoxField = forwardRef(
       validate,
       validateFields,
       value,
+      size,
     }: TextBoxFieldProps,
     ref: Ref<HTMLInputElement>,
   ): JSX.Element => {
@@ -105,9 +103,7 @@ const TextBoxField = forwardRef(
     const validateFn = useValidation<TextBoxValue>({
       validate,
       validators: pickValidators({
-        max,
         maxLength,
-        min,
         minLength,
         regex,
         required,
@@ -139,10 +135,8 @@ const TextBoxField = forwardRef(
           ? getFirstError<string>({
               allValues: values,
               label,
-              max,
               maxLength,
               meta: meta as FieldState<string>,
-              min,
               minLength,
               name,
               regex,
@@ -153,10 +147,8 @@ const TextBoxField = forwardRef(
         getFirstError,
         input.value,
         label,
-        max,
         maxLength,
         meta,
-        min,
         minLength,
         name,
         regex,
@@ -177,14 +169,13 @@ const TextBoxField = forwardRef(
         error={error}
         id={id}
         label={label}
-        max={max}
+        size={size}
         maxLength={maxLength}
-        min={min}
         minLength={minLength}
         multiline={multiline}
         name={input.name}
         notice={notice}
-        onBlur={(event: FocusEvent<HTMLInputElement>) => {
+        onBlur={(event: FocusEvent<HTMLTextAreaElement>) => {
           input.onBlur(event)
           onBlur?.(event)
         }}
@@ -192,7 +183,7 @@ const TextBoxField = forwardRef(
           input.onChange(event)
           onChange?.(event)
         }}
-        onFocus={(event: FocusEvent<HTMLInputElement>) => {
+        onFocus={(event: FocusEvent<HTMLTextAreaElement>) => {
           input.onFocus(event)
           onFocus?.(event)
         }}


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

I added size to textBoxField and submit as we can customise those properties. 

@DorianMaliszewski I'm not sure of the purpose of `min` and `max` into `TextBoxField`, those properties doesn't exists in `TextBox` in Scaleway UI 🤔 



