### PR TITLE
feat: add label to regex validation

### DIFF
--- a/src/components/Submit/__tests__/index.spec.tsx
+++ b/src/components/Submit/__tests__/index.spec.tsx
@@ -27,7 +27,7 @@ describe('Submit', () => {
   test('form is invalid', () =>
     shouldMatchEmotionSnapshot(
       <Form initialValues={{ toto: '4' }} errors={mockErrors}>
-        <TextBoxField name="toto" regex={[alpha]} />
+        <TextBoxField name="toto" regex={[{ value: alpha }]} />
         <Submit>Test</Submit>
       </Form>,
     ))

--- a/src/components/TextBoxField/__stories__/index.stories.tsx
+++ b/src/components/TextBoxField/__stories__/index.stories.tsx
@@ -82,5 +82,5 @@ export const Regex: Story<ComponentProps<typeof TextBoxField>> = args => (
 
 Regex.args = {
   name: 'Regex',
-  regex: [/^[a-zA-Z]*$/],
+  regex: [{ label: 'only letters', value: /^[a-zA-Z]*$/ }],
 }

--- a/src/components/TextBoxField/index.tsx
+++ b/src/components/TextBoxField/index.tsx
@@ -11,7 +11,7 @@ import { useField, useFormState } from 'react-final-form'
 import pickValidators from '../../helpers/pickValidators'
 import useValidation from '../../hooks/useValidation'
 import { useErrors } from '../../providers/ErrorContext'
-import { BaseFieldProps } from '../../types'
+import { BaseFieldProps, LabeledRegex } from '../../types'
 
 type TextBoxValue = NonNullable<ComponentProps<typeof TextBox>['value']>
 
@@ -49,7 +49,7 @@ type TextBoxFieldProps<T = TextBoxValue, K = string> = BaseFieldProps<T, K> &
     className?: string
     max?: number
     min?: number
-    regex?: (RegExp | RegExp[])[]
+    regex?: LabeledRegex[]
   }
 
 const TextBoxField = forwardRef(

--- a/src/mocks/mockErrors.ts
+++ b/src/mocks/mockErrors.ts
@@ -8,11 +8,11 @@ const mockErrors: FormErrors = {
   MIN_LENGTH: ({ minLength }) =>
     `This field should have a length greater than ${minLength}`,
   REGEX: ({ regex }) =>
-    `This field should match the regex ${regex
+    `This field should match ${regex
       .map(r =>
         Array.isArray(r)
-          ? r.map(nestedRegex => nestedRegex.source).join(' or ')
-          : r.source,
+          ? r.map(nestedRegex => nestedRegex.label).join(' or ')
+          : r.label,
       )
       .join(' and ')}`,
   REQUIRED: 'This field is required',

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,9 @@ type RequiredErrors = {
     | string
   REGEX:
     | ((
-        params: FormErrorFunctionParams & { regex: (RegExp | RegExp[])[] },
+        params: FormErrorFunctionParams & {
+          regex: (LabeledRegex | LabeledRegex[])[]
+        },
       ) => string)
     | string
   REQUIRED: ((params: FormErrorFunctionParams) => string) | string
@@ -63,13 +65,18 @@ type RequiredErrors = {
 
 export type FormErrors = RequiredErrors
 
+export type LabeledRegex = {
+  value: RegExp
+  label?: string
+}
+
 export type ValidatorProps = {
   required?: boolean
   min?: number
   minLength?: number
   max?: number
   maxLength?: number
-  regex?: (RegExp | RegExp[])[]
+  regex?: LabeledRegex | LabeledRegex[]
   maxDate?: Date
   minDate?: Date
 }

--- a/src/validators/__tests__/regex.spec.ts
+++ b/src/validators/__tests__/regex.spec.ts
@@ -5,24 +5,24 @@ const digits = /^[0-9]*$/
 
 describe('regex validator', () => {
   test('should not throw error', () => {
-    const validator = regex([alpha])
+    const validator = regex([{ value: alpha }])
     expect(validator).toBeDefined()
     expect(validator.error).toBe('REGEX')
   })
 
   test('should success', () => {
-    const validator = regex([alpha])
+    const validator = regex([{ value: alpha }])
     expect(validator.validate('test', {})).toBe(true)
   })
 
   test('should failed', () => {
-    const validator = regex([alpha])
+    const validator = regex([{ value: alpha }])
     expect(validator.validate('a1', {})).toBe(false)
     expect(validator.validate('a+', {})).toBe(false)
   })
 
   test('should support or value', () => {
-    const validator = regex([[alpha, digits]])
+    const validator = regex([[{ value: alpha }, { value: digits }]])
     expect(validator.validate('test', {})).toBe(true)
     expect(validator.validate('1234', {})).toBe(true)
   })

--- a/src/validators/regex.ts
+++ b/src/validators/regex.ts
@@ -1,12 +1,16 @@
+import { LabeledRegex } from '../types'
 import { ValidatorFn } from './types'
 
-const validator: ValidatorFn<string, (RegExp | RegExp[])[]> = regexes => ({
+const validator: ValidatorFn<
+  string,
+  (LabeledRegex | LabeledRegex[])[]
+> = regexes => ({
   error: 'REGEX',
   validate: value =>
     regexes.every(regex =>
       Array.isArray(regex)
-        ? regex.some(regexOr => regexOr.test(value))
-        : regex.test(value),
+        ? regex.some(regexOr => regexOr.value.test(value))
+        : regex.value.test(value),
     ),
 })
 


### PR DESCRIPTION
## Summary

Add optional label to regex validation prop to be able to build user-friendly errors

## Type

- Enhancement

### Summarise concisely:

With these changes, `regex` validation prop is expecting a value and a label.

Then it allows us to use the label to parse better error messages.

## Relevant logs and/or screenshots

Before | After
 :-:   | -:
<img width="1063" alt="CleanShot 2022-07-28 at 16 35 01@2x" src="https://user-images.githubusercontent.com/16015833/181557464-3acdacf7-9e22-48ef-83cc-131b49952977.png"> | <img width="1061" alt="CleanShot 2022-07-28 at 16 35 21@2x" src="https://user-images.githubusercontent.com/16015833/181557592-29fc8615-bc53-460b-986d-bf30692d8fba.png">



