### PR TITLE
fix(richSelect): error when untouched

### DIFF
--- a/src/components/RichSelectField/index.tsx
+++ b/src/components/RichSelectField/index.tsx
@@ -175,7 +175,7 @@ const RichSelectField = <
   const error = useMemo(() => {
     if (errorProp) return errorProp
 
-    return meta.error
+    return meta.error && meta.touched
       ? getFirstError({
           allValues: values,
           label,


### PR DESCRIPTION
## Summary

Make sure not to display rich select field error when the input hasn't been touched

## Type

- Bug



