### PR TITLE
feat(richSelect): forward noTopLabel prop

### DIFF
--- a/src/components/RichSelectField/index.tsx
+++ b/src/components/RichSelectField/index.tsx
@@ -47,6 +47,7 @@ export type RichSelectFieldProps<
     | 'readOnly'
     | 'required'
     | 'value'
+    | 'noTopLabel'
   > & {
     label?: string
     maxLength?: number
@@ -88,6 +89,7 @@ const RichSelectField = <
   readOnly,
   required,
   value,
+  noTopLabel,
 }: RichSelectFieldProps<T>) => {
   const { values } = useFormState()
   const validate = useValidation({
@@ -218,6 +220,7 @@ const RichSelectField = <
       placeholder={placeholder}
       readOnly={readOnly}
       value={input.value}
+      noTopLabel={noTopLabel}
     >
       {children}
     </RichSelect>


### PR DESCRIPTION
## Summary

Forward the `noTopLabel` prop on `RichSelectField` in order to disable the top label.

## Type

- Enhancement



