### PR TITLE
fix: required={false} should work

### DIFF
--- a/src/validators/__tests__/required.spec.ts
+++ b/src/validators/__tests__/required.spec.ts
@@ -10,11 +10,14 @@ describe('required validator', () => {
     expect(required(undefined).validate('test', {})).toBe(true)
     expect(required(undefined).validate(true, {})).toBe(true)
     expect(required(undefined).validate({}, {})).toBe(true)
+    expect(required(false).validate('', {})).toBe(true)
+    expect(required(false).validate(undefined, {})).toBe(true)
+    expect(required(false).validate(false, {})).toBe(true)
   })
 
   test('should failed', () => {
-    expect(required(undefined).validate('', {})).toBe(false)
-    expect(required(undefined).validate(undefined, {})).toBe(false)
-    expect(required(undefined).validate(false, {})).toBe(false)
+    expect(required(true).validate('', {})).toBe(false)
+    expect(required(true).validate(undefined, {})).toBe(false)
+    expect(required(true).validate(false, {})).toBe(false)
   })
 })

--- a/src/validators/required.ts
+++ b/src/validators/required.ts
@@ -1,8 +1,8 @@
 import { ValidatorFn } from './types'
 
-const requiredValidator: ValidatorFn = () => ({
+const requiredValidator: ValidatorFn = required => ({
   error: 'REQUIRED',
-  validate: (value: unknown) => !!value,
+  validate: (value: unknown) => (required ? !!value : true),
 })
 
 export default requiredValidator


### PR DESCRIPTION
## Summary

Make sure setting `required` to `false` is working as expected.

## Type

- Bug

### Summarise concisely:

Right now, if I set the `required` prop to explicitly `false`, it will be ignored and the field will be `required`. This PR fixes this issue



