### PR TITLE
feat: unify get field error

### DIFF
--- a/src/components/CheckboxField/index.tsx
+++ b/src/components/CheckboxField/index.tsx
@@ -1,13 +1,7 @@
 import { Checkbox } from '@scaleway/ui'
 import { FieldState } from 'final-form'
-import React, {
-  ComponentProps,
-  ReactNode,
-  Ref,
-  forwardRef,
-  useMemo,
-} from 'react'
-import { useField, useFormState } from 'react-final-form'
+import React, { ComponentProps, ReactNode, Ref, forwardRef } from 'react'
+import { useField } from 'react-final-form'
 import pickValidators from '../../helpers/pickValidators'
 import useValidation from '../../hooks/useValidation'
 import { useErrors } from '../../providers/ErrorContext'
@@ -54,8 +48,7 @@ const CheckboxField = forwardRef(
     }: CheckboxFieldProps,
     ref: Ref<HTMLLabelElement>,
   ): JSX.Element => {
-    const { values } = useFormState()
-    const { getFirstError } = useErrors()
+    const { getError } = useErrors()
 
     const validateFn = useValidation<CheckboxValue>({
       validate,
@@ -70,19 +63,12 @@ const CheckboxField = forwardRef(
       value,
     })
 
-    const error = useMemo(
-      () =>
-        meta.error && meta.touched
-          ? getFirstError({
-              allValues: values,
-              label,
-              meta: meta as FieldState<string | boolean | undefined>,
-              name,
-              value: input.value ?? input.checked,
-            })
-          : undefined,
-      [getFirstError, input.checked, label, meta, name, values, input.value],
-    )
+    const error = getError({
+      label,
+      meta: meta as FieldState<unknown>,
+      name,
+      value: input.value ?? input.checked,
+    })
 
     return (
       <Checkbox

--- a/src/components/DateField/index.tsx
+++ b/src/components/DateField/index.tsx
@@ -1,7 +1,7 @@
 import { DateInput } from '@scaleway/ui'
 import { FieldState } from 'final-form'
-import React, { ComponentProps, useMemo } from 'react'
-import { useField, useFormState } from 'react-final-form'
+import React, { ComponentProps } from 'react'
+import { useField } from 'react-final-form'
 import pickValidators from '../../helpers/pickValidators'
 import useValidation from '../../hooks/useValidation'
 import { useErrors } from '../../providers/ErrorContext'
@@ -55,8 +55,7 @@ const DateField = ({
   onFocus,
   formatOnBlur,
 }: DateFieldProps) => {
-  const { values } = useFormState()
-  const { getFirstError } = useErrors()
+  const { getError } = useErrors()
   const validateFn = useValidation<Date>({
     validate,
     validators: pickValidators<Date>({
@@ -73,21 +72,14 @@ const DateField = ({
     value: inputVal,
   })
 
-  const error = useMemo(
-    () =>
-      meta.error && (!isEmpty(input.value) || meta.touched)
-        ? getFirstError<Date>({
-            allValues: values,
-            label,
-            maxDate,
-            meta: meta as FieldState<Date>,
-            minDate,
-            name,
-            value: input.value,
-          })
-        : undefined,
-    [getFirstError, input.value, label, maxDate, meta, minDate, name, values],
-  )
+  const error = getError({
+    label,
+    maxDate,
+    meta: meta as FieldState<unknown>,
+    minDate,
+    name,
+    value: input.value,
+  })
 
   return (
     <DateInput

--- a/src/components/RadioBorderedBoxField/index.tsx
+++ b/src/components/RadioBorderedBoxField/index.tsx
@@ -1,7 +1,7 @@
 import { RadioBorderedBox } from '@scaleway/ui'
 import { FieldState } from 'final-form'
-import React, { ComponentProps, ReactNode, useMemo } from 'react'
-import { useField, useFormState } from 'react-final-form'
+import React, { ComponentProps, ReactNode } from 'react'
+import { useField } from 'react-final-form'
 import pickValidators from '../../helpers/pickValidators'
 import useValidation from '../../hooks/useValidation'
 import { useErrors } from '../../providers/ErrorContext'
@@ -51,8 +51,7 @@ const RadioBorderedBoxField = ({
   validate,
   value,
 }: RadioBorderedBoxFieldProps): JSX.Element => {
-  const { values } = useFormState()
-  const { getFirstError } = useErrors()
+  const { getError } = useErrors()
 
   const validateFn = useValidation<RadioBorderedBoxValue>({
     validate,
@@ -67,19 +66,12 @@ const RadioBorderedBoxField = ({
     value,
   })
 
-  const error = useMemo(
-    () =>
-      meta.error
-        ? getFirstError({
-            allValues: values,
-            label,
-            meta: meta as FieldState<string | number>,
-            name,
-            value: input.value,
-          })
-        : undefined,
-    [getFirstError, input.value, label, meta, name, values],
-  )
+  const error = getError({
+    label,
+    meta: meta as FieldState<unknown>,
+    name,
+    value: input.value,
+  })
 
   return (
     <RadioBorderedBox

--- a/src/components/RadioField/index.tsx
+++ b/src/components/RadioField/index.tsx
@@ -1,7 +1,7 @@
 import { Radio } from '@scaleway/ui'
 import { FieldState } from 'final-form'
-import React, { ComponentProps, ReactNode, useMemo } from 'react'
-import { useField, useFormState } from 'react-final-form'
+import React, { ComponentProps, ReactNode } from 'react'
+import { useField } from 'react-final-form'
 import pickValidators from '../../helpers/pickValidators'
 import useValidation from '../../hooks/useValidation'
 import { useErrors } from '../../providers/ErrorContext'
@@ -38,8 +38,7 @@ const RadioField = ({
   validate,
   value,
 }: RadioFieldProps): JSX.Element => {
-  const { values } = useFormState()
-  const { getFirstError } = useErrors()
+  const { getError } = useErrors()
 
   const validateFn = useValidation<RadioValue>({
     validate,
@@ -54,19 +53,12 @@ const RadioField = ({
     value,
   })
 
-  const error = useMemo(
-    () =>
-      meta.error
-        ? getFirstError({
-            allValues: values,
-            label,
-            meta: meta as FieldState<string | number>,
-            name,
-            value: input.value,
-          })
-        : undefined,
-    [getFirstError, input.value, label, meta, name, values],
-  )
+  const error = getError({
+    label,
+    meta: meta as FieldState<unknown>,
+    name,
+    value: input.value,
+  })
 
   return (
     <Radio

--- a/src/components/RichSelectField/index.tsx
+++ b/src/components/RichSelectField/index.tsx
@@ -7,7 +7,7 @@ import React, {
   useCallback,
   useMemo,
 } from 'react'
-import { useField, useFormState } from 'react-final-form'
+import { useField } from 'react-final-form'
 import pickValidators from '../../helpers/pickValidators'
 import useValidation from '../../hooks/useValidation'
 import { useErrors } from '../../providers/ErrorContext'
@@ -91,7 +91,7 @@ const RichSelectField = <
   value,
   noTopLabel,
 }: RichSelectFieldProps<T>) => {
-  const { values } = useFormState()
+  const { getError } = useErrors()
   const validate = useValidation({
     validators: pickValidators<T>({
       maxLength,
@@ -173,20 +173,13 @@ const RichSelectField = <
     value,
   })
 
-  const { getFirstError } = useErrors()
-  const error = useMemo(() => {
-    if (errorProp) return errorProp
-
-    return meta.error && meta.touched
-      ? getFirstError({
-          allValues: values,
-          label,
-          meta: meta as FieldState<T | undefined>,
-          name,
-          value,
-        })
-      : undefined
-  }, [getFirstError, label, meta, name, value, errorProp, values])
+  const error = getError({
+    errorProp,
+    label,
+    meta: meta as FieldState<unknown>,
+    name,
+    value: input.value,
+  })
 
   return (
     <RichSelect

--- a/src/components/SelectableCardField/index.tsx
+++ b/src/components/SelectableCardField/index.tsx
@@ -1,7 +1,7 @@
 import { SelectableCard } from '@scaleway/ui'
 import { FieldState } from 'final-form'
-import React, { ComponentProps, useMemo } from 'react'
-import { useField, useFormState } from 'react-final-form'
+import React, { ComponentProps } from 'react'
+import { useField } from 'react-final-form'
 import pickValidators from '../../helpers/pickValidators'
 import useValidation from '../../hooks/useValidation'
 import { useErrors } from '../../providers/ErrorContext'
@@ -52,8 +52,7 @@ const SelectableCardField = ({
   tooltip,
   id,
 }: SelectableCardFieldProps): JSX.Element => {
-  const { values } = useFormState()
-  const { getFirstError } = useErrors()
+  const { getError } = useErrors()
 
   const validateFn = useValidation<SelectableCardValue>({
     validate,
@@ -68,19 +67,12 @@ const SelectableCardField = ({
     value,
   })
 
-  const error = useMemo(
-    () =>
-      meta.error
-        ? getFirstError({
-            allValues: values,
-            label: name,
-            meta: meta as FieldState<string | number>,
-            name,
-            value: input.value,
-          })
-        : undefined,
-    [getFirstError, input.value, meta, name, values],
-  )
+  const error = getError({
+    label: name,
+    meta: meta as FieldState<unknown>,
+    name,
+    value: input.value,
+  })
 
   return (
     <SelectableCard

--- a/src/components/Submit/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/Submit/__tests__/__snapshots__/index.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`Submit form is invalid 1`] = `
   position: relative;
 }
 
-.cache-16jruyc {
+.cache-1l46zoq {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -33,55 +33,66 @@ exports[`Submit form is invalid 1`] = `
   padding-right: 20px;
   padding-top: 14px;
   padding: 8px;
+  border-color: #dd3252;
 }
 
-.cache-16jruyc::-webkit-input-placeholder {
+.cache-1l46zoq::-webkit-input-placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-16jruyc::-moz-placeholder {
+.cache-1l46zoq::-moz-placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-16jruyc:-ms-input-placeholder {
+.cache-1l46zoq:-ms-input-placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-16jruyc::placeholder {
+.cache-1l46zoq::placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-16jruyc:hover,
-.cache-16jruyc:focus {
+.cache-1l46zoq:hover,
+.cache-1l46zoq:focus {
   border-color: #4f0599;
 }
 
-.cache-16jruyc:focus {
+.cache-1l46zoq:focus {
   box-shadow: 0px 0px 0px 3px #4F059940;
   border-color: #4f0599;
 }
 
-.cache-16jruyc::-webkit-input-placeholder {
+.cache-1l46zoq::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-16jruyc::-moz-placeholder {
+.cache-1l46zoq::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-16jruyc:-ms-input-placeholder {
+.cache-1l46zoq:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-16jruyc::placeholder {
+.cache-1l46zoq::placeholder {
   opacity: 1;
 }
 
-.cache-xcx33n {
+.cache-1l46zoq:hover,
+.cache-1l46zoq:focus {
+  border-color: #a6102d;
+}
+
+.cache-1l46zoq:focus {
+  box-shadow: 0px 0px 0px 3px #DD325240;
+  border-color: #a6102d;
+}
+
+.cache-9xime5 {
   -webkit-transition: max-height 300ms ease-out,opacity 300ms ease-out;
   transition: max-height 300ms ease-out,opacity 300ms ease-out;
   max-height: 0;
@@ -89,9 +100,14 @@ exports[`Submit form is invalid 1`] = `
   opacity: 0;
   height: auto;
   margin-top: 0;
+  -webkit-transition: max-height 300ms ease-in,opacity 300ms ease-in;
+  transition: max-height 300ms ease-in,opacity 300ms ease-in;
+  max-height: 56px;
+  opacity: 1;
+  overflow: visible;
 }
 
-.cache-xcx33n.cache-xcx33n {
+.cache-9xime5.cache-9xime5 {
   overflow: hidden;
 }
 
@@ -191,18 +207,20 @@ exports[`Submit form is invalid 1`] = `
       >
         <input
           autocomplete="on"
-          class="cache-16jruyc e18bmnpq1"
+          class="cache-1l46zoq e18bmnpq1"
           name="toto"
           type="text"
           value="4"
         />
       </div>
       <div
-        class="e14o3tsk0 cache-xcx33n"
+        class="e14o3tsk0 cache-9xime5"
       >
         <div
           class="cache-1rshnsu e18bmnpq3"
-        />
+        >
+          This field should match the regex ^[a-zA-Z]*$
+        </div>
       </div>
     </div>
     <button

--- a/src/components/TextBoxField/index.tsx
+++ b/src/components/TextBoxField/index.tsx
@@ -1,13 +1,7 @@
 import { TextBox } from '@scaleway/ui'
 import { FieldState } from 'final-form'
-import React, {
-  ComponentProps,
-  FocusEvent,
-  Ref,
-  forwardRef,
-  useMemo,
-} from 'react'
-import { useField, useFormState } from 'react-final-form'
+import React, { ComponentProps, FocusEvent, Ref, forwardRef } from 'react'
+import { useField } from 'react-final-form'
 import pickValidators from '../../helpers/pickValidators'
 import useValidation from '../../hooks/useValidation'
 import { useErrors } from '../../providers/ErrorContext'
@@ -101,8 +95,7 @@ const TextBoxField = forwardRef(
     }: TextBoxFieldProps,
     ref: Ref<HTMLInputElement>,
   ): JSX.Element => {
-    const { values } = useFormState()
-    const { getFirstError } = useErrors()
+    const { getError } = useErrors()
 
     const validateFn = useValidation<TextBoxValue>({
       validate,
@@ -135,36 +128,17 @@ const TextBoxField = forwardRef(
       value,
     })
 
-    const error = useMemo(
-      () =>
-        meta.error && meta.touched
-          ? getFirstError<string>({
-              allValues: values,
-              label,
-              max,
-              maxLength,
-              meta: meta as FieldState<string>,
-              min,
-              minLength,
-              name,
-              regex,
-              value: input.value,
-            })
-          : undefined,
-      [
-        getFirstError,
-        input.value,
-        label,
-        max,
-        maxLength,
-        meta,
-        min,
-        minLength,
-        name,
-        regex,
-        values,
-      ],
-    )
+    const error = getError({
+      label,
+      max,
+      maxLength,
+      meta: meta as FieldState<unknown>,
+      min,
+      minLength,
+      name,
+      regex,
+      value: input.value,
+    })
 
     return (
       <TextBox

--- a/src/providers/ErrorContext/__tests__/index.spec.tsx
+++ b/src/providers/ErrorContext/__tests__/index.spec.tsx
@@ -1,16 +1,23 @@
 import { renderHook } from '@testing-library/react'
 import React, { ReactNode } from 'react'
+import { Form as ReactFinalForm } from 'react-final-form'
 import ErrorProvider, { useErrors } from '..'
 import { shouldMatchEmotionSnapshot } from '../../../helpers/jestHelpers'
 import mockErrors from '../../../mocks/mockErrors'
 
 const HookWrapper = ({ children }: { children: ReactNode }) => (
-  <ErrorProvider errors={mockErrors}>{children}</ErrorProvider>
+  <ReactFinalForm
+    onSubmit={jest.fn()}
+    render={() => <ErrorProvider errors={mockErrors}>{children}</ErrorProvider>}
+  />
 )
 describe('ErrorProvider', () => {
   test('renders correctly ', () =>
     shouldMatchEmotionSnapshot(
-      <ErrorProvider errors={mockErrors}>Test</ErrorProvider>,
+      <ReactFinalForm
+        onSubmit={jest.fn()}
+        render={() => <ErrorProvider errors={mockErrors}>Test</ErrorProvider>}
+      />,
     ))
   test('should use context', () => {
     const { result } = renderHook(() => useErrors(), {
@@ -19,16 +26,14 @@ describe('ErrorProvider', () => {
 
     expect(result.current.errors).toStrictEqual(mockErrors)
     expect(
-      result.current.getFirstError({
-        allValues: {},
+      result.current.getError({
         label: 'test',
         name: 'test',
         value: 'test',
       }),
-    ).toStrictEqual('')
+    ).toStrictEqual(undefined)
     expect(
-      result.current.getFirstError({
-        allValues: {},
+      result.current.getError({
         label: 'test',
         meta: {
           blur: () => {},
@@ -36,6 +41,7 @@ describe('ErrorProvider', () => {
           error: ['REQUIRED'],
           focus: () => {},
           name: 'test',
+          touched: true,
         },
         name: 'test',
         value: '',
@@ -43,7 +49,7 @@ describe('ErrorProvider', () => {
     ).toStrictEqual(mockErrors.REQUIRED)
 
     expect(
-      result.current.getFirstError({
+      result.current.getError({
         allValues: {},
         label: 'test',
         meta: {
@@ -52,6 +58,7 @@ describe('ErrorProvider', () => {
           error: ['MIN_LENGTH'],
           focus: () => {},
           name: 'test',
+          touched: true,
         },
         minLength: 3,
         name: 'test',
@@ -61,7 +68,7 @@ describe('ErrorProvider', () => {
 
     const customErrorString = 'This is an error'
     expect(
-      result.current.getFirstError({
+      result.current.getError({
         allValues: {},
         label: 'test',
         meta: {
@@ -70,6 +77,7 @@ describe('ErrorProvider', () => {
           error: customErrorString,
           focus: () => {},
           name: 'test',
+          touched: true,
         },
         minLength: 3,
         name: 'test',
@@ -79,7 +87,7 @@ describe('ErrorProvider', () => {
 
     // to cover all code branches and default values
     expect(
-      result.current.getFirstError({
+      result.current.getError({
         allValues: {},
         label: 'test',
         meta: {
@@ -93,6 +101,6 @@ describe('ErrorProvider', () => {
         name: 'test',
         value: '',
       }),
-    ).toEqual('')
+    ).toEqual(undefined)
   })
 })

--- a/src/providers/ErrorContext/index.tsx
+++ b/src/providers/ErrorContext/index.tsx
@@ -6,13 +6,15 @@ import React, {
   useContext,
   useMemo,
 } from 'react'
+import { useFormState } from 'react-final-form'
 import { FormErrorFunctionParams, FormErrors } from '../../types'
+
+type GetErrorProps = Omit<FormErrorFunctionParams, 'allValues'> &
+  AnyObject & { errorProp?: string; additionalErrorChecks?: boolean }
 
 type ErrorContextValue = {
   errors: FormErrors
-  getFirstError: <T = unknown>(
-    params: FormErrorFunctionParams<T> & AnyObject,
-  ) => string
+  getError: (props: GetErrorProps) => string | undefined
 }
 const ErrorContext = createContext({} as ErrorContextValue)
 
@@ -24,15 +26,16 @@ const ErrorProvider = ({
   children,
   errors,
 }: ErrorProviderProps): JSX.Element => {
+  const { values } = useFormState()
+
   const getFirstError = useCallback(
     ({
-      allValues,
       label,
       name,
       value,
       meta,
       ...additionalParams
-    }: FormErrorFunctionParams & AnyObject) => {
+    }: Omit<FormErrorFunctionParams, 'allValues'> & AnyObject) => {
       if (meta?.error && Array.isArray(meta.error)) {
         return (
           meta.error
@@ -40,11 +43,11 @@ const ErrorProvider = ({
               const key = untypedKey as keyof typeof errors
               if (typeof errors[key] === 'function') {
                 return (errors[key] as (params: AnyObject) => string)({
-                  allValues,
                   label,
                   meta,
                   name,
                   value,
+                  values,
                   ...additionalParams,
                 })
               }
@@ -59,16 +62,27 @@ const ErrorProvider = ({
 
       return ''
     },
-    [errors],
+    [errors, values],
+  )
+
+  const getError = useCallback(
+    ({ meta, errorProp, ...props }: GetErrorProps) => {
+      if (errorProp) return errorProp
+
+      return meta?.touched && meta.error
+        ? getFirstError({ meta, ...props })
+        : undefined
+    },
+    [getFirstError],
   )
 
   const value = useMemo(
     () =>
       ({
         errors,
-        getFirstError,
+        getError,
       } as ErrorContextValue),
-    [errors, getFirstError],
+    [errors, getError],
   )
 
   return <ErrorContext.Provider value={value}>{children}</ErrorContext.Provider>

--- a/src/providers/ErrorContext/index.tsx
+++ b/src/providers/ErrorContext/index.tsx
@@ -66,11 +66,17 @@ const ErrorProvider = ({
   )
 
   const getError = useCallback(
-    ({ meta, errorProp, ...props }: GetErrorProps) => {
+    ({ meta, errorProp, value, ...props }: GetErrorProps) => {
       if (errorProp) return errorProp
 
-      return meta?.touched && meta.error
-        ? getFirstError({ meta, ...props })
+      const hasInitialValueAndNotTouched =
+        value !== undefined &&
+        value !== null &&
+        value !== '' &&
+        meta?.dirty === false
+
+      return meta?.error && (hasInitialValueAndNotTouched || meta.touched)
+        ? getFirstError({ meta, value, ...props })
         : undefined
     },
     [getFirstError],


### PR DESCRIPTION
## Describe

For each field we used to always did the following:

```tsx
const { values } = useFormState()
const { getFirstError } = useErrors()

const error = useMemo(
      () =>
        meta.error && meta.touched
          ? getFirstError({
              allValues: values,
              label,
              meta,
              name,
              value: input.value,
            })
          : undefined,
      [getFirstError, input.checked, label, meta, name, values, input.value],
    )
```

This PR unifies it so that we only need to call a `getError` function:

```tsx
const { getError } = useErrors()

const error = getError({
      label,
      meta,
      name,
      value: input.value,
    })
```

Error checking is also more reliable. It handles the case where the input has an invalid initial value.

## Type

- Refactor
