### PR TITLE
fix(validation): min and max length when value is undefined

### DIFF
--- a/src/validators/maxLength.ts
+++ b/src/validators/maxLength.ts
@@ -2,7 +2,7 @@ import { ValidatorFn } from './types'
 
 const maxLengthValidator: ValidatorFn<string, number> = maxLength => ({
   error: 'MAX_LENGTH',
-  validate: value => value?.length <= maxLength,
+  validate: value => (value?.length ?? 0) <= maxLength,
 })
 
 export default maxLengthValidator

--- a/src/validators/minLength.ts
+++ b/src/validators/minLength.ts
@@ -2,7 +2,7 @@ import { ValidatorFn } from './types'
 
 const minLengthValidator: ValidatorFn<string, number> = minLength => ({
   error: 'MIN_LENGTH',
-  validate: value => value?.length >= minLength,
+  validate: value => (value?.length ?? 0) >= minLength,
 })
 
 export default minLengthValidator


### PR DESCRIPTION
## Summary

When `maxLength` is set, form has error even when input value is undefined. This PR fixes this.

## Type

- Bug



