### PR TITLE
fix: richselect forward required prop

### DIFF
--- a/src/components/RichSelectField/index.tsx
+++ b/src/components/RichSelectField/index.tsx
@@ -214,6 +214,7 @@ const RichSelectField = <
       readOnly={readOnly}
       value={input.value}
       noTopLabel={noTopLabel}
+      required={required}
     >
       {children}
     </RichSelect>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Forward prop required to the RichSelect component

#### The following changes where made:

1. Add required prop


