### PR TITLE
fix(ci): display correct initial page on storybook load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ WORKDIR /workspace
 
 COPY --from=builder /usr/src/app/storybook-static .
 
-RUN npm add -g serve
+RUN npm add -g local-web-server
 
-CMD serve -l 80
+CMD ws --hostname localhost -p 80


### PR DESCRIPTION
Use local-web-server instead of serve to serve the storybook

fix #483


