### PR TITLE
ci: use static-web-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,19 +9,17 @@ COPY package.json pnpm-lock.yaml ./
 RUN corepack enable
 RUN pnpm install --frozen-lockfile
 
-COPY . .
+COPY src ./src
+COPY .storybook ./.storybook
 
 RUN pnpm run build:storybook
 
 ######################################################################
 # This stage download a simple http server and serve the application #
 ######################################################################
-FROM node:18.10-alpine
+FROM joseluisq/static-web-server:2
 
 WORKDIR /workspace
 
-COPY --from=builder /usr/src/app/storybook-static .
+COPY --from=builder /usr/src/app/storybook-static ./public
 
-RUN npm add -g serve
-
-CMD serve -l 80


### PR DESCRIPTION
Use [static-web-server](https://github.com/joseluisq/static-web-server) instead of serve to serve the storybook.

**It's blazingly fast**

fixes #483



