### PR TITLE
fix: validation when field is not required

### DIFF
--- a/src/validators/max.ts
+++ b/src/validators/max.ts
@@ -2,7 +2,7 @@ import { ValidatorFn } from './types'
 
 const maxValidator: ValidatorFn<number> = max => ({
   error: 'TOO_HIGH',
-  validate: value => Number(value) <= max,
+  validate: value => value === undefined || Number(value) <= max,
 })
 
 export default maxValidator

--- a/src/validators/maxDate.ts
+++ b/src/validators/maxDate.ts
@@ -2,7 +2,7 @@ import { ValidatorFn } from './types'
 
 const maxDateValidator: ValidatorFn<Date, Date> = maxDate => ({
   error: 'MAX_DATE',
-  validate: value => value <= maxDate,
+  validate: value => value === undefined || value <= maxDate,
 })
 
 export default maxDateValidator

--- a/src/validators/maxLength.ts
+++ b/src/validators/maxLength.ts
@@ -2,7 +2,7 @@ import { ValidatorFn } from './types'
 
 const maxLengthValidator: ValidatorFn<string, number> = maxLength => ({
   error: 'MAX_LENGTH',
-  validate: value => (value?.length ?? 0) <= maxLength,
+  validate: value => value === undefined || value.length <= maxLength,
 })
 
 export default maxLengthValidator

--- a/src/validators/min.ts
+++ b/src/validators/min.ts
@@ -2,7 +2,7 @@ import { ValidatorFn } from './types'
 
 const minValidator: ValidatorFn<number> = min => ({
   error: 'TOO_LOW',
-  validate: value => Number(value) >= min,
+  validate: value => value === undefined || Number(value) >= min,
 })
 
 export default minValidator

--- a/src/validators/minDate.ts
+++ b/src/validators/minDate.ts
@@ -2,7 +2,7 @@ import { ValidatorFn } from './types'
 
 const minDateValidator: ValidatorFn<Date, Date> = minDate => ({
   error: 'MIN_DATE',
-  validate: value => value >= minDate,
+  validate: value => value === undefined || value >= minDate,
 })
 
 export default minDateValidator

--- a/src/validators/minLength.ts
+++ b/src/validators/minLength.ts
@@ -2,7 +2,7 @@ import { ValidatorFn } from './types'
 
 const minLengthValidator: ValidatorFn<string, number> = minLength => ({
   error: 'MIN_LENGTH',
-  validate: value => (value?.length ?? 0) >= minLength,
+  validate: value => value === undefined || value.length >= minLength,
 })
 
 export default minLengthValidator

--- a/src/validators/regex.ts
+++ b/src/validators/regex.ts
@@ -3,10 +3,12 @@ import { ValidatorFn } from './types'
 const validator: ValidatorFn<string, (RegExp | RegExp[])[]> = regexes => ({
   error: 'REGEX',
   validate: value =>
-    regexes.every(regex =>
-      Array.isArray(regex)
-        ? regex.some(regexOr => regexOr.test(value))
-        : regex.test(value),
+    regexes.every(
+      regex =>
+        value === undefined ||
+        (Array.isArray(regex)
+          ? regex.some(regexOr => regexOr.test(value))
+          : regex.test(value)),
     ),
 })
 


### PR DESCRIPTION
## Summary

When field is not required, other validation shouldn't be applied when field is empty

## Type

- Bug



