### PR TITLE
fix: infinite rendering when passing form render props

### DIFF
--- a/src/hooks/useFormField.ts
+++ b/src/hooks/useFormField.ts
@@ -36,6 +36,8 @@ export const useFormField = <
     minDate,
   }: UseFieldConfig<FieldValue, InputValue> & ValidatorProps,
 ) => {
+  const serializedRegex = useMemo(() => regex?.toString(), [regex])
+
   const validators = useMemo(
     () =>
       pickValidators<FieldValue>({
@@ -48,7 +50,17 @@ export const useFormField = <
         regex,
         required,
       }),
-    [max, maxLength, min, minLength, regex, required, maxDate, minDate],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      max,
+      maxLength,
+      min,
+      minLength,
+      required,
+      serializedRegex,
+      maxDate,
+      minDate,
+    ],
   )
 
   const validateFn = useValidation({ validate, validators })


### PR DESCRIPTION
We now serialize regex validation prop to a string and give this to the `useCallback` so that it only re-trigger when regex really changes


